### PR TITLE
Removed "scope: 'openid profile'" references

### DIFF
--- a/examples/firebase-sample/platforms/ios/www/lib/auth0-angular/README.md
+++ b/examples/firebase-sample/platforms/ios/www/lib/auth0-angular/README.md
@@ -66,7 +66,7 @@ angular.module('myCoolApp').controller('LoginCtrl', function(auth) {
   $scope.signin = function() {
     auth.signin({
       authParams: {
-        scope: 'openid profile' // This is if you want the full JWT
+        scope: 'openid name email' // This is if you want the full JWT
       }
     }, function(profile, idToken, accessToken, state, refreshToken) {
       $location.path('/user-info')
@@ -94,7 +94,7 @@ angular.module('myCoolApp').controller('UserInfoCtrl', function(auth) {
 ````
 ````html
 <!-- userInfo.html -->
-<span>{{profile.first_name}} {{profile.email}}</span>
+<span>{{profile.name}} {{profile.email}}</span>
 ````
 
 ### Keeping the user logged in, saving the token and using a refresh token.

--- a/examples/firebase-sample/platforms/ios/www/lib/auth0.js/README.md
+++ b/examples/firebase-sample/platforms/ios/www/lib/auth0.js/README.md
@@ -171,7 +171,8 @@ Once you have succesfully authenticated, Auth0 will redirect to your `callbackUR
   });
 ```
 
-Or just parse the hash (if loginOption.scope is not `openid profile`, then the profile will only contains the `user_id`):
+Or just parse the hash (if loginOption.scope is `openid`, then the profile will only contain the `user_id`):
+Taking this into consideration: `openid`: It will return, not only the access_token, but also an id_token which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use constant `ParemterBuilder.SCOPE_OPENID`.
 
 ```js
   $(function () {
@@ -252,7 +253,7 @@ If you just want to get a new token for an addon that you've activated, you can 
 var options = {
   id_token: "your id token", // The id_token you have now
   api: 'firebase', // This defaults to the first active addon if any or you can specify this
-  "scope": "openid profile"		    // default: openid
+  "scope": "openid name email"		    // default: openid
 };
 
 auth0.getDelegationToken(options, function (err, delegationResult) {

--- a/examples/firebase-sample/www/lib/auth0-angular/README.md
+++ b/examples/firebase-sample/www/lib/auth0-angular/README.md
@@ -66,7 +66,7 @@ angular.module('myCoolApp').controller('LoginCtrl', function(auth) {
   $scope.signin = function() {
     auth.signin({
       authParams: {
-        scope: 'openid profile' // This is if you want the full JWT
+        scope: 'openid name email' // This is if you want the full JWT
       }
     }, function(profile, idToken, accessToken, state, refreshToken) {
       $location.path('/user-info')
@@ -94,7 +94,7 @@ angular.module('myCoolApp').controller('UserInfoCtrl', function(auth) {
 ````
 ````html
 <!-- userInfo.html -->
-<span>{{profile.first_name}} {{profile.email}}</span>
+<span>{{profile.name}} {{profile.email}}</span>
 ````
 
 ### Keeping the user logged in, saving the token and using a refresh token.

--- a/examples/firebase-sample/www/lib/auth0.js/README.md
+++ b/examples/firebase-sample/www/lib/auth0.js/README.md
@@ -171,7 +171,8 @@ Once you have succesfully authenticated, Auth0 will redirect to your `callbackUR
   });
 ```
 
-Or just parse the hash (if loginOption.scope is not `openid profile`, then the profile will only contains the `user_id`):
+Or just parse the hash (if loginOption.scope is `openid`, then the profile will only contain the `user_id`):
+Taking this into consideration: `openid`: It will return, not only the access_token, but also an id_token which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use constant `ParemterBuilder.SCOPE_OPENID`.
 
 ```js
   $(function () {
@@ -252,7 +253,7 @@ If you just want to get a new token for an addon that you've activated, you can 
 var options = {
   id_token: "your id token", // The id_token you have now
   api: 'firebase', // This defaults to the first active addon if any or you can specify this
-  "scope": "openid profile"		    // default: openid
+  "scope": "openid name email"		    // default: openid
 };
 
 auth0.getDelegationToken(options, function (err, delegationResult) {

--- a/examples/refresh-token-sample/platforms/ios/www/lib/auth0-angular/README.md
+++ b/examples/refresh-token-sample/platforms/ios/www/lib/auth0-angular/README.md
@@ -66,7 +66,7 @@ angular.module('myCoolApp').controller('LoginCtrl', function(auth) {
   $scope.signin = function() {
     auth.signin({
       authParams: {
-        scope: 'openid profile' // This is if you want the full JWT
+        scope: 'openid name email'
       }
     }, function() {
       $location.path('/user-info')
@@ -94,7 +94,7 @@ angular.module('myCoolApp').controller('UserInfoCtrl', function(auth) {
 ````
 ````html
 <!-- userInfo.html -->
-<span>{{profile.first_name}} {{profile.email}}</span>
+<span>{{profile.name}} {{profile.email}}</span>
 ````
 
 ### Keeping the user logged in, saving the token and using a refresh token.

--- a/examples/refresh-token-sample/platforms/ios/www/lib/auth0.js/README.md
+++ b/examples/refresh-token-sample/platforms/ios/www/lib/auth0.js/README.md
@@ -171,7 +171,8 @@ Once you have succesfully authenticated, Auth0 will redirect to your `callbackUR
   });
 ```
 
-Or just parse the hash (if loginOption.scope is not `openid profile`, then the profile will only contains the `user_id`):
+Or just parse the hash (if loginOption.scope is `openid`, then the profile will only contain the `user_id`):
+Taking this into consideration: `openid`: It will return, not only the access_token, but also an id_token which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use constant `ParemterBuilder.SCOPE_OPENID`.
 
 ```js
   $(function () {
@@ -246,7 +247,7 @@ If you just want to get a new token for an addon that you've activated, you can 
 var options = {
   id_token: "your id token", // The id_token you have now
   api: 'firebase', // This defaults to the first active addon if any or you can specify this
-  "scope": "openid profile"		    // default: openid
+  "scope": "openid name email"		    // default: openid
 };
 
 auth0.getDelegationToken(options, function (err, delegationResult) {

--- a/examples/refresh-token-sample/www/lib/auth0-angular/README.md
+++ b/examples/refresh-token-sample/www/lib/auth0-angular/README.md
@@ -66,7 +66,7 @@ angular.module('myCoolApp').controller('LoginCtrl', function(auth) {
   $scope.signin = function() {
     auth.signin({
       authParams: {
-        scope: 'openid profile' // This is if you want the full JWT
+        scope: 'openid name email'
       }
     }, function() {
       $location.path('/user-info')
@@ -94,7 +94,7 @@ angular.module('myCoolApp').controller('UserInfoCtrl', function(auth) {
 ````
 ````html
 <!-- userInfo.html -->
-<span>{{profile.first_name}} {{profile.email}}</span>
+<span>{{profile.name}} {{profile.email}}</span>
 ````
 
 ### Keeping the user logged in, saving the token and using a refresh token.

--- a/examples/refresh-token-sample/www/lib/auth0.js/README.md
+++ b/examples/refresh-token-sample/www/lib/auth0.js/README.md
@@ -171,7 +171,8 @@ Once you have succesfully authenticated, Auth0 will redirect to your `callbackUR
   });
 ```
 
-Or just parse the hash (if loginOption.scope is not `openid profile`, then the profile will only contains the `user_id`):
+Or just parse the hash (if loginOption.scope is `openid`, then the profile will only contain the `user_id`):
+Taking this into consideration: `openid`: It will return, not only the access_token, but also an id_token which is a Json Web Token (JWT). The JWT will only contain the user id (sub claim). You can use constant `ParemterBuilder.SCOPE_OPENID`.
 
 ```js
   $(function () {
@@ -246,7 +247,7 @@ If you just want to get a new token for an addon that you've activated, you can 
 var options = {
   id_token: "your id token", // The id_token you have now
   api: 'firebase', // This defaults to the first active addon if any or you can specify this
-  "scope": "openid profile"		    // default: openid
+  "scope": "openid name email"		    // default: openid
 };
 
 auth0.getDelegationToken(options, function (err, delegationResult) {


### PR DESCRIPTION
All “scope: ‘openid profile’” references have been replaced by “scope:
‘openid name email’” to avoid possible maxlength errors and truncation
issues.