### PR TITLE
Replace call to heroku

### DIFF
--- a/examples/refresh-token-sample/README.md
+++ b/examples/refresh-token-sample/README.md
@@ -1,6 +1,6 @@
 # Auth0 + Ionic + API Sample
 
-This is a sample Ionic project that uses Auth0 for Authentication. 
+This is a sample Ionic project that uses Auth0 for Authentication.
 It's the basic [tabs](https://github.com/driftyco/ionic-starter-tabs) example from [Ionic](http://ionicframework.com/) with the added authentication from Auth0.
 
 This example uses [Refresh Tokens](https://github.com/auth0/auth0-angular/blob/master/docs/refreshToken.md) so that you will see the Login page only the first time you create the app and then never again.
@@ -14,6 +14,10 @@ Once you have that, just clone the project and run the following:
 2. `ionic platform add ios`
 3. `ionic build ios`
 4. `ionic emulate ios`
+
+## Running an API to call
+
+To try out the secured API call in this sample, you can get the Auth0 NodeJS API seed project from: https://auth0.com/docs/quickstart/backend/nodejs/ and just run it alongside this Ionic sample.
 
 Enjoy your Ionic app now :).
 

--- a/examples/refresh-token-sample/www/js/controllers.js
+++ b/examples/refresh-token-sample/www/js/controllers.js
@@ -23,15 +23,17 @@ angular.module('starter.controllers', [])
   });
 
   doAuth();
-  
-  
+
+
 })
 
 .controller('DashCtrl', function($scope, $http) {
   $scope.callApi = function() {
     // Just call the API as you'd do using $http
     $http({
-      url: 'http://auth0-nodejsapi-sample.herokuapp.com/secured/ping',
+      // You can get our Auth0 NodeJS seed project to host
+      // the secured API from here: https://auth0.com/docs/quickstart/backend/nodejs/
+      url: 'http://localhost:3001/secured/ping',
       method: 'GET'
     }).then(function() {
       alert("We got the secured data successfully");


### PR DESCRIPTION
Replaces the call to the secured API hosted in heroku with a call to
localhost, since the packager will use the Auth0 user credentials to
build the seed project and the Heroku sample app will not be able to
validate the call.

Fixes https://github.com/auth0/auth0-ionic/issues/35